### PR TITLE
Fix for error message 'document is nil' is about the filter in the Fi…

### DIFF
--- a/blog/blog_server/server.go
+++ b/blog/blog_server/server.go
@@ -184,7 +184,7 @@ func (*server) DeleteBlog(ctx context.Context, req *blogpb.DeleteBlogRequest) (*
 func (*server) ListBlog(req *blogpb.ListBlogRequest, stream blogpb.BlogService_ListBlogServer) error {
 	fmt.Println("List blog request")
 
-	cur, err := collection.Find(context.Background(), nil)
+	cur, err := collection.Find(context.Background(), bson.D{‌{}})
 	if err != nil {
 		return status.Errorf(
 			codes.Internal,


### PR DESCRIPTION
### The error message "document is nil" is about the filter in the Find(). Change the line

`cur, err := collection.Find(context.Background(), nil)`
to
`cur, err := collection.Find(context.Background(), bson.D{‌{}})`


_Thank you for all your teaching. "This was the best teacher's course"_