### PR TITLE
passed intentional err argument

### DIFF
--- a/greet/greet_server/server.go
+++ b/greet/greet_server/server.go
@@ -83,8 +83,8 @@ func (*server) GreetEveryone(stream greetpb.GreetService_GreetEveryoneServer) er
 			Result: result,
 		})
 		if sendErr != nil {
-			log.Fatalf("Error while sending data to client: %v", err)
-			return err
+			log.Fatalf("Error while sending data to client: %v", sendErr)
+			return sendErr
 		}
 	}
 


### PR DESCRIPTION
In the video lecture, 2 `err` was not modified to `sendErr`.