### PR TITLE
update mongo syntax and remove unnecessary control character

### DIFF
--- a/blog/blog_server/server.go
+++ b/blog/blog_server/server.go
@@ -184,7 +184,7 @@ func (*server) DeleteBlog(ctx context.Context, req *blogpb.DeleteBlogRequest) (*
 func (*server) ListBlog(req *blogpb.ListBlogRequest, stream blogpb.BlogService_ListBlogServer) error {
 	fmt.Println("List blog request")
 
-	cur, err := collection.Find(context.Background(), bson.D{‌{}})
+	cur, err := collection.Find(context.Background(), bson.D{{}})
 	if err != nil {
 		return status.Errorf(
 			codes.Internal,
@@ -219,7 +219,7 @@ func main() {
 
 	fmt.Println("Connecting to MongoDB")
 	// connect to MongoDB
-	client, err := mongo.NewClient("mongodb://localhost:27017")
+	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR fixes the errors below.
```
$ go run blog/blog_server/server.go
# command-line-arguments
blog/blog_server/server.go:187:59: invalid identifier character U+200C
blog/blog_server/server.go:187:59: undefined: ‌
blog/blog_server/server.go:222:33: cannot use "mongodb://localhost:27017" (type string) as type *options.ClientOptions in argument to mongo.NewClient
```

> invalid identifier character U+200C

appears between open curly brackets like this.

```diff
$ git diff
diff --git a/blog/blog_server/server.go b/blog/blog_server/server.go
index 77f880c..51b0364 100644
--- a/blog/blog_server/server.go
+++ b/blog/blog_server/server.go
@@ -184,7 +184,7 @@ func (*server) DeleteBlog(ctx context.Context, req *blogpb.DeleteBlogRequest) (*
 func (*server) ListBlog(req *blogpb.ListBlogRequest, stream blogpb.BlogService_ListBlogServer) error {
        fmt.Println("List blog request")
 
-       cur, err := collection.Find(context.Background(), bson.D{<U+200C>{}})
+       cur, err := collection.Find(context.Background(), bson.D{{}})
        if err != nil {
                return status.Errorf(
                        codes.Internal,
```