### PR TITLE
Re-ordering the differents closings

### DIFF
--- a/blog/blog_server/server.go
+++ b/blog/blog_server/server.go
@@ -255,11 +255,20 @@ func main() {
 
 	// Block until a signal is received
 	<-ch
-	fmt.Println("Stopping the server")
-	s.Stop()
-	fmt.Println("Closing the listener")
-	lis.Close()
+	<-ch
+	// First we close the connection with MongoDB:
 	fmt.Println("Closing MongoDB Connection")
-	client.Disconnect(context.TODO())
-	fmt.Println("End of Program")
+    client.Disconnect(context.TODO())	
+	if err := client.Disconnect(context.TODO()); err != nil {
+        log.Fatalf("Error on disconnection with MongoDB : %v", err)
+    }
+    // Second step : closing the listener
+    fmt.Println("Closing the listener")
+    if err := lis.Close(); err != nil {
+         log.Fatalf("Error on closing the listener : %v", err)
+     }
+     // Finally, we stop the server
+     fmt.Println("Stopping the server")
+     s.Stop()
+     fmt.Println("End of Program")
 }


### PR DESCRIPTION
With the current code, the order of the different closings/stoppings generate errors : "accept tcp [::]:50051: use of closed network connection".

So, we have to close properly like this :
- first : the connection withe the MongoDB server
- second : closing the listener
- third : stopping our server
