### PR TITLE
Fixed issue with greet deadline example to use context.DeadlineExceed…

### DIFF
--- a/greet/greet_server/server.go
+++ b/greet/greet_server/server.go
@@ -93,7 +93,7 @@ func (*server) GreetEveryone(stream greetpb.GreetService_GreetEveryoneServer) er
 func (*server) GreetWithDeadline(ctx context.Context, req *greetpb.GreetWithDeadlineRequest) (*greetpb.GreetWithDeadlineResponse, error) {
 	fmt.Printf("GreetWithDeadline function was invoked with %v\n", req)
 	for i := 0; i < 3; i++ {
-		if ctx.Err() == context.Canceled {
+		if ctx.Err() == context.DeadlineExceeded {
 			// the client canceled the request
 			fmt.Println("The client canceled the request!")
 			return nil, status.Error(codes.Canceled, "the client canceled the request")


### PR DESCRIPTION
…ed instead of context.Cancelled