### PR TITLE
Disconnecting the client auto-closes all listeners

### DIFF
--- a/blog/blog_server/server.go
+++ b/blog/blog_server/server.go
@@ -261,11 +261,6 @@ func main() {
 	if err := client.Disconnect(context.TODO()); err != nil {
         	log.Fatalf("Error on disconnection with MongoDB : %v", err)
     	}
-    	// Second step : closing the listener
-    	fmt.Println("Closing the listener")
-    	if err := lis.Close(); err != nil {
-        	log.Fatalf("Error on closing the listener : %v", err)
-	}
 	// Finally, we stop the server
 	fmt.Println("Stopping the server")
     	s.Stop()


### PR DESCRIPTION
if you see grpc\server.go in func (s *Server) Stop() there is already code which closes all listeners on line 1648. Closing listeners manually can cause weird errors, especially if you do it after server stop