### PR TITLE
Used correct context in server funcs, removed listener closing

### DIFF
--- a/blog/blog_client/client.go
+++ b/blog/blog_client/client.go
@@ -20,7 +20,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not connect: %v", err)
 	}
-	defer cc.Close()
+	defer cc.Close() // Maybe this should be in a separate function and the error handled?
 
 	c := blogpb.NewBlogServiceClient(cc)
 


### PR DESCRIPTION
Used correct context:
 - You were getting ctx and assigning to var but never using it
 - An alternative to my fix would be `func Whatever(_ context.Context)` as an argument instead

Struct inheritance:
 - In never versions of GRPC, you're now required to inherit from your protobuf generated file's server interface. For the blog that's `blogpb.BlogServiceServer`. I think this should be reflected in the tutorials too. It took me a bit to figure it out and there are questions about it in the Udemy Q&A
 
Listener closing removal:
 - This is unnecessary and it can cause some issues and head scratching later on (especially if you do it AFTER you call server.Stop() :D . If you take a look at the GRPC Server's Stop() func you will see it already closes all its listeners. When I was following along, I did my lis.Close() after s.Stop() and kept getting weird "Listener is not listening/inactive" errors etc:
 ```
 func (s *Server) Stop() {
	// Omitted

	listeners := s.lis
	s.lis = nil
	
    // Omitted

	for lis := range listeners {
		lis.Close()
	}
```
Hope this helps and it would be great to include the newer requirements/semantics in the course! :)